### PR TITLE
add test for blazar "hosts in lease" API

### DIFF
--- a/src/blazar_tempest_plugin/services/reservation/leases_client.py
+++ b/src/blazar_tempest_plugin/services/reservation/leases_client.py
@@ -6,6 +6,7 @@ from blazar_tempest_plugin.services.reservation import base
 class LeasesClient(base.BaseReservableResourceClient):
     lease_uri = "/leases"
     lease_path_uri = "/leases/%s"
+    lease_hosts_uri = "/leases/%s/hosts"
 
     def list_leases(self):
         return self.list_resources(self.lease_uri)
@@ -31,3 +32,7 @@ class LeasesClient(base.BaseReservableResourceClient):
         uri = self.lease_path_uri % lease_id
         update_body = {**kwargs}
         return self.update_resource(uri, update_body)
+
+    def show_hosts_in_lease(self, lease_id):
+        uri = self.lease_hosts_uri % lease_id
+        return self.show_resource(uri)

--- a/src/blazar_tempest_plugin/tests/scenario/base.py
+++ b/src/blazar_tempest_plugin/tests/scenario/base.py
@@ -108,6 +108,11 @@ class ReservationScenarioTest(manager.ScenarioTest):
             if res["resource_type"] == "physical:host":
                 return res["id"]
 
+    def _get_reserved_hosts(self, lease):
+        leases_hosts_body = self.leases_client.show_hosts_in_lease(lease["id"])
+        hosts = [h for h in leases_hosts_body.get("hosts", [])]
+        return hosts
+
 
 class ReservableNetworkScenarioTest(
     ReservationScenarioTest, manager.NetworkScenarioTest
@@ -210,7 +215,7 @@ class ReservableNetworkScenarioTest(
             )
         except lib_exc.TimeoutException:
             LOG.error(
-                "Server ports failed transitioning to ACTIVE for " "server: %s", server
+                "Server ports failed transitioning to ACTIVE for server: %s", server
             )
             raise
 

--- a/src/blazar_tempest_plugin/tests/scenario/test_oshost_basic_ops.py
+++ b/src/blazar_tempest_plugin/tests/scenario/test_oshost_basic_ops.py
@@ -33,8 +33,12 @@ class TestReservableBaremetalNode(ReservationScenarioTest):
     @decorators.attr(type="slow")
     def test_reservable_server_basic_ops(self):
         lease = self._reserve_physical_host()
+
+        reserved_hosts = self._get_reserved_hosts(lease)
+        LOG.info(f"got reserved_hosts {reserved_hosts}")
+
         reservation_id = self._get_host_reservation(lease)
-        LOG.debug(f"got reservation id {reservation_id}")
+        LOG.info(f"got reservation id {reservation_id}")
 
         keypair = self.create_keypair()
         self.instance = self.create_server(


### PR DESCRIPTION
We've added a "list hosts in lease" API to blazar. This commit adds:
- a basic method to call the api
- a basic test case for the api
- and uses the api to print out what was reserved for scenario tests, to aid in debugging nova scheduler failures (e.g. why is "this node" bad)