### PR TITLE
Add initial smoke tests for images

### DIFF
--- a/src/blazar_tempest_plugin/common/utils.py
+++ b/src/blazar_tempest_plugin/common/utils.py
@@ -47,7 +47,7 @@ def should_skip(check_name, check_regex):
     Check if a test should be skipped based on the configuration.
 
     For example, on KVM we want to skip 2 tests:
-    skip_test_regex = verify_rclone_and_object_store|verify_openrc
+    cc_image_tests_skip_test_regex = verify_rclone_and_object_store|verify_openrc
     """
     if check_regex and re.fullmatch(check_regex, check_name):
         return True

--- a/src/blazar_tempest_plugin/config.py
+++ b/src/blazar_tempest_plugin/config.py
@@ -40,6 +40,11 @@ ReservationGroup = [
         "reservable_flavor_ref",
         help="flavor to use for reservable instances",
     ),
+    cfg.BoolOpt(
+        "reservation_required",
+        default=True,
+        help="If False, run tests on on-demand KVM and skip all Blazar reservations.",
+     ),
 ]
 
 ReservationFeaturesGroup = [
@@ -80,5 +85,20 @@ ImageGroup = [
         "image_protected_properties",
         default=[],
         help=("A list of keys for which glance property protection is enabled."),
+    ),
+    cfg.ListOpt(
+        "image_names",
+        default=[],
+        help=("A comma-separated list of image names to test (e.g. CC-Ubuntu24.04,CC-Ubuntu22.04)."),
+    ),
+    cfg.StrOpt(
+        "skip_test_regex",
+        default='',
+        help=("Regex for test method names to skip during image tests (e.g. verify_rclone_and_object_store|verify_openrc)."),
+    ),
+    cfg.StrOpt(
+        "openrc_path",
+        default="/home/cc/openrc",
+        help="Path to the openrc file on the server used in image tests.",
     ),
 ]

--- a/src/blazar_tempest_plugin/config.py
+++ b/src/blazar_tempest_plugin/config.py
@@ -87,17 +87,17 @@ ImageGroup = [
         help=("A list of keys for which glance property protection is enabled."),
     ),
     cfg.ListOpt(
-        "image_names",
+        "cc_image_tests_image_names",
         default=[],
         help=("A comma-separated list of image names to test (e.g. CC-Ubuntu24.04,CC-Ubuntu22.04)."),
     ),
     cfg.StrOpt(
-        "skip_test_regex",
+        "cc_image_tests_skip_test_regex",
         default='',
         help=("Regex for test method names to skip during image tests (e.g. verify_rclone_and_object_store|verify_openrc)."),
     ),
     cfg.StrOpt(
-        "openrc_path",
+        "cc_image_tests_openrc_path",
         default="/home/cc/openrc",
         help="Path to the openrc file on the server used in image tests.",
     ),

--- a/src/blazar_tempest_plugin/tests/scenario/base.py
+++ b/src/blazar_tempest_plugin/tests/scenario/base.py
@@ -2,7 +2,6 @@ import time
 
 from oslo_log import log as logging
 from tempest import config
-from tempest.common import compute
 from tempest.common import waiters as lib_waiters
 from tempest.lib import exceptions as lib_exc
 from tempest.lib.common.utils import data_utils, test_utils
@@ -22,9 +21,9 @@ class ReservationScenarioTest(manager.ScenarioTest):
     @classmethod
     def skip_checks(cls):
         super().skip_checks()
-        if not CONF.service_available.blazar:
-            skip_msg = "Blazar is disabled"
-            raise cls.skipException(skip_msg)
+        if CONF.reservation.reservation_required:
+            if not CONF.service_available.blazar:
+                raise cls.skipException("Blazar is disabled but reservation_required=True")
 
     @classmethod
     def setup_credentials(cls):

--- a/src/blazar_tempest_plugin/tests/scenario/test_images.py
+++ b/src/blazar_tempest_plugin/tests/scenario/test_images.py
@@ -32,20 +32,20 @@ def verify_cloud_init(self, remote):
 
 def verify_openrc_exists(self, remote):
     self.assertTrue(
-        wait_for_remote_file(remote, CONF.image.openrc_path),
-        f"{CONF.image.openrc_path} did not appear within timeout"
+        wait_for_remote_file(remote, CONF.image.cc_image_tests_openrc_path),
+        f"{CONF.image.cc_image_tests_openrc_path} did not appear within timeout"
     )
 
 
 def verify_openrc(self, remote):
     self.assertTrue(
-        wait_for_remote_file(remote, CONF.image.openrc_path),
-        f"{CONF.image.openrc_path} did not appear within timeout"
+        wait_for_remote_file(remote, CONF.image.cc_image_tests_openrc_path),
+        f"{CONF.image.cc_image_tests_openrc_path} did not appear within timeout"
     )
     output = remote.exec_command(
-        f'bash -c "source {CONF.image.openrc_path} && openstack token issue -f value -c id" || echo FAILED'
+        f'bash -c "source {CONF.image.cc_image_tests_openrc_path} && openstack token issue -f value -c id" || echo FAILED'
     )
-    self.assertNotIn("FAILED", output, f"Failed to source {CONF.image.openrc_path} or run OpenStack command.")
+    self.assertNotIn("FAILED", output, f"Failed to source {CONF.image.cc_image_tests_openrc_path} or run OpenStack command.")
     self.assertTrue(output.strip(), "OpenStack command produced no output — openrc may not have been sourced correctly.")
 
 
@@ -222,7 +222,7 @@ def make_image_test_class(image_name):
     for test_name, test_func in TESTS:
         def make_test(test_name, test_func):
             def test_fn(self):
-                if should_skip(test_name, CONF.image.skip_test_regex):
+                if should_skip(test_name, CONF.image.cc_image_tests_skip_test_regex):
                     self.skipTest(f"{test_name} skipped")
                 if test_name == "verify_ssh_key_injection":
                     test_func(self, type(self).remote, type(self).public_key)
@@ -247,7 +247,7 @@ def generate_tests():
     created_classes = set()
     module = sys.modules[__name__]
 
-    for image_name in getattr(CONF.image, "image_names", []):
+    for image_name in getattr(CONF.image, "cc_image_tests_image_names", []):
         image_name = image_name.strip()
         if image_name in created_classes:
             LOG.warning(f"Skipping duplicate image_name in config: {image_name}")

--- a/src/blazar_tempest_plugin/tests/scenario/test_images.py
+++ b/src/blazar_tempest_plugin/tests/scenario/test_images.py
@@ -1,0 +1,265 @@
+import sys
+
+from oslo_log import log as logging
+from tempest import config
+from tempest.common import waiters as tempest_waiters
+from tempest.lib import decorators
+from tempest.lib import exceptions as tempest_exc
+from tempest.lib.common.utils import test_utils
+
+from blazar_tempest_plugin.common import waiters
+from blazar_tempest_plugin.common.utils import get_server_floating_ip
+from blazar_tempest_plugin.common.utils import should_skip
+from blazar_tempest_plugin.common.utils import wait_for_remote_file
+from blazar_tempest_plugin.tests.scenario.base import ReservationScenarioTest
+
+
+CONF = config.CONF
+LOG = logging.getLogger(__name__)
+
+
+### Tests ###
+
+def verify_cloud_init(self, remote):
+    output = remote.exec_command('cloud-init status --wait')
+    if "status: done" not in output:
+        self.fail(f"cloud-init did not finish properly.\nOutput:\n{output}")
+
+    output = remote.exec_command('cloud-init status --long')
+    if "status: done" not in output:
+        self.fail(f"cloud-init did not finish properly.\nOutput:\n{output}")
+
+
+def verify_openrc_exists(self, remote):
+    self.assertTrue(
+        wait_for_remote_file(remote, CONF.image.openrc_path),
+        f"{CONF.image.openrc_path} did not appear within timeout"
+    )
+
+
+def verify_openrc(self, remote):
+    self.assertTrue(
+        wait_for_remote_file(remote, CONF.image.openrc_path),
+        f"{CONF.image.openrc_path} did not appear within timeout"
+    )
+    output = remote.exec_command(
+        f'bash -c "source {CONF.image.openrc_path} && openstack token issue -f value -c id" || echo FAILED'
+    )
+    self.assertNotIn("FAILED", output, f"Failed to source {CONF.image.openrc_path} or run OpenStack command.")
+    self.assertTrue(output.strip(), "OpenStack command produced no output — openrc may not have been sourced correctly.")
+
+
+def verify_ssh_key_injection(self, remote, public_key):
+    output = remote.exec_command('cat /home/cc/.ssh/authorized_keys || echo MISSING')
+    self.assertNotIn("MISSING", output, "Could not read /home/cc/.ssh/authorized_keys")
+
+    pubkey_str = public_key.strip()
+    auth_keys = output.strip().splitlines()
+    self.assertIn(pubkey_str, auth_keys, f"Expected pubkey not found.\nGot:\n{output}")
+
+
+def verify_rclone_and_object_store(self, remote):
+    output = remote.exec_command('which rclone || echo MISSING')
+    self.assertNotIn("MISSING", output, "'rclone' was not found on the instance.")
+
+    output = remote.exec_command('which cc-mount-object-store || echo MISSING')
+    self.assertNotIn("MISSING", output, "'cc-mount-object-store' not found.")
+
+    output = remote.exec_command('cc-mount-object-store list || echo ERROR')
+    self.assertNotIn("ERROR", output, "cc-mount-object-store list returned error.")
+    self.assertTrue(output.strip() and not all(c == '.' for c in output.strip()),
+                    "'cc-mount-object-store list' output is invalid.")
+
+
+TESTS = [
+    ("verify_cloud_init", verify_cloud_init),
+    ("verify_openrc_exists", verify_openrc_exists),
+    ("verify_ssh_key_injection", verify_ssh_key_injection),
+    ("verify_rclone_and_object_store", verify_rclone_and_object_store),
+    ("verify_openrc", verify_openrc),
+]
+
+
+### Dynamic Test Class Creation ###
+
+def make_image_test_class(image_name):
+    """
+    Dynamically create a test class for the given image name.
+
+    The classes created by this function will inherit from
+    `ReservationScenarioTest` and will include tests for various
+    functionalities such as SSH key injection, cloud-init verification,
+    and more. Each class will be named `TestImage_<image_name>`, where
+    `<image_name>` is the sanitized version of the image name. The
+    image name is sanitized by replacing special characters with
+    underscores to ensure it is a valid Python class name.
+
+    If there are multiple images with the same name, an exception
+    will be raised. If no image is found, an exception will also be
+    raised.
+
+    The test methods will be dynamically added to the class based on the
+    `TESTS` list defined above, skipping any that should be skipped,
+    as specified by the `skip_test_regex` configuration option.
+
+    The class will also include a setup method that creates a server
+    using the specified image, and a teardown method that cleans up
+    the server and any associated resources.
+    """
+    safe_name = image_name.replace(":", "_").replace("-", "_").replace(".", "_")
+    class_name = f"TestImage_{safe_name}"
+
+    class TestImage(ReservationScenarioTest):
+        @classmethod
+        def setUpClass(cls):
+            super().setUpClass()
+            inst = cls()
+
+            resp = cls.image_client.list_images(params={
+                'name': image_name,
+                'visibility': 'public',
+            })
+            matching = resp.get('images', [])
+
+            if not matching:
+                raise Exception(f"No image found with name: {image_name}")
+            if len(matching) > 1:
+                raise Exception(f"Multiple images found with name: {image_name}")
+
+            cls.image = matching[0]
+            cls.image_id = cls.image['id']
+            cls.image_name = image_name
+
+            cls.keypair = inst.create_keypair()
+            cls.public_key = cls.keypair["public_key"]
+            cls.lease_id = None
+
+            try:
+                if CONF.reservation.reservation_required:
+                    lease = inst._reserve_physical_host()
+                    cls.lease_id = lease["id"]
+                    reservation_id = inst._get_host_reservation(lease)
+                    flavor = CONF.reservation.reservable_flavor_ref
+                    scheduler_hints = {"reservation": reservation_id}
+                else:
+                    flavor = CONF.compute.flavor_ref
+                    scheduler_hints = {}
+
+                boot_kwargs = {
+                    "image_id": cls.image_id,
+                    "keypair": cls.keypair,
+                    "wait_until": "SSHABLE",
+                    "flavor": flavor,
+                }
+                if scheduler_hints:
+                    boot_kwargs["scheduler_hints"] = scheduler_hints
+
+                server = inst.create_server(**boot_kwargs)
+                cls.server_id = server["id"]
+                # refresh server details to get security groups and floating IP
+                server = cls.servers_client.show_server(cls.server_id)["server"]
+                cls._created_sg_names = []
+                for sg in server.get("security_groups", []):
+                    name = sg.get("name")
+                    if name != "default":
+                        cls._created_sg_names.append(name)
+                cls.fip = get_server_floating_ip(server)
+                cls.remote = cls.get_remote_client(cls, cls.fip)
+
+            except Exception:
+                if cls.lease_id:
+                    test_utils.call_and_ignore_notfound_exc(
+                        cls.leases_client.delete_lease, cls.lease_id
+                    )
+                raise
+
+        @classmethod
+        def tearDownClass(cls):
+            try:
+                if hasattr(cls, "server_id"):
+                    cls.servers_client.delete_server(cls.server_id)
+                    tempest_waiters.wait_for_server_termination(cls.servers_client, cls.server_id)
+
+                if getattr(cls, "lease_id", None):
+                    try:
+                        test_utils.call_and_ignore_notfound_exc(
+                            cls.leases_client.delete_lease, cls.lease_id
+                        )
+                        waiters.wait_for_lease_status(
+                            cls.leases_client, cls.lease_id, "TERMINATED"
+                        )
+                    except tempest_exc.NotFound:
+                        pass
+
+                if hasattr(cls, "fip"):
+                    try:
+                        floating_ips = cls.floating_ips_client.list_floatingips()['floatingips']
+                        matching = [fip for fip in floating_ips if fip['floating_ip_address'] == cls.fip]
+                        if matching:
+                            cls.floating_ips_client.delete_floatingip(matching[0]['id'])
+                    except tempest_exc.NotFound:
+                        pass
+
+                if hasattr(cls, "keypair"):
+                    try:
+                        cls.keypairs_client.delete_keypair(cls.keypair["name"])
+                    except tempest_exc.NotFound:
+                        pass
+
+                for name in getattr(cls, "_created_sg_names", []):
+                    sgs = cls.security_groups_client.list_security_groups(
+                        name=name
+                    )['security_groups']
+                    for sg in sgs:
+                        sg_id = sg['id']
+                        try:
+                            cls.security_groups_client.delete_security_group(sg_id)
+                        except tempest_exc.NotFound:
+                            pass
+            finally:
+                super().tearDownClass()
+
+    for test_name, test_func in TESTS:
+        def make_test(test_name, test_func):
+            def test_fn(self):
+                if should_skip(test_name, CONF.image.skip_test_regex):
+                    self.skipTest(f"{test_name} skipped")
+                if test_name == "verify_ssh_key_injection":
+                    test_func(self, type(self).remote, type(self).public_key)
+                else:
+                    test_func(self, type(self).remote)
+            test_fn.__name__ = f"test_{test_name}"
+            test_fn.__qualname__ = f"{class_name}.{test_fn.__name__}"
+            test_fn.__module__ = __name__
+            return decorators.attr(type="smoke")(test_fn)
+
+        test_method = make_test(test_name, test_func)
+        setattr(TestImage, test_method.__name__, test_method)
+
+    TestImage.__name__ = class_name
+    TestImage.__qualname__ = class_name
+    return TestImage
+
+
+def generate_tests():
+    """Dynamically generate test classes for images listed in the config."""
+
+    created_classes = set()
+    module = sys.modules[__name__]
+
+    for image_name in getattr(CONF.image, "image_names", []):
+        image_name = image_name.strip()
+        if image_name in created_classes:
+            LOG.warning(f"Skipping duplicate image_name in config: {image_name}")
+            continue
+
+        test_cls = make_image_test_class(image_name)
+        setattr(module, test_cls.__name__, test_cls)
+        created_classes.add(image_name)
+
+
+if not globals().get("__image_tests_generated__"):
+    # Ensure tests are generated only once and not multiple times
+    # due to tempest potentially importing this module multiple times
+    generate_tests()
+    __image_tests_generated__ = True


### PR DESCRIPTION
The creation of the image test classes (and tests on those classes) is a bit messy in order to be dynamic depending on which images are specified in the config file for a site.

For example, if `etc/tempest.conf` for a site specifies:
```
[image]
image_names = CC-Ubuntu24.04,CC-Ubuntu22.04
skip_test_regex = verify_rclone_and_object_store|verify_openrc
```

Then this will create a TestImage class for each of those images, and the setup/teardown for those classes will happen once per image. The test methods (except the skpped tests) will be attached to the class and run by tempest. E.g.:
```
$ tempest run --exclude-list etc/exclude_list --concurrency 1 --regex "blazar_tempest_plugin.tests.scenario.test_images"
{0} blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_Ubuntu22_04.test_verify_cloud_init [8.496844s] ... ok
{0} blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_Ubuntu22_04.test_verify_openrc ... SKIPPED: verify_openrc skipped
{0} blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_Ubuntu22_04.test_verify_openrc_exists [0.576417s] ... ok
{0} blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_Ubuntu22_04.test_verify_rclone_and_object_store ... SKIPPED: verify_rclone_and_object_store skipped
{0} blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_Ubuntu22_04.test_verify_ssh_key_injection [0.580653s] ... ok
{0} blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_Ubuntu24_04.test_verify_cloud_init [5.602323s] ... ok
{0} blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_Ubuntu24_04.test_verify_openrc ... SKIPPED: verify_openrc skipped
{0} blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_Ubuntu24_04.test_verify_openrc_exists [0.601985s] ... ok
{0} blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_Ubuntu24_04.test_verify_rclone_and_object_store ... SKIPPED: verify_rclone_and_object_store skipped
{0} blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_Ubuntu24_04.test_verify_ssh_key_injection [0.601958s] ... ok

======
Totals
======
Ran: 10 tests in 59.1142 sec.
 - Passed: 6
 - Skipped: 4
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 16.4614 sec.
```

While not perfectly straightforward I think this code is fairly readable all things considered and should allow for maximum flexibility going forward testing different images at different sites as defined solely by configuration (and also test it in the most sane way: that is, booting a server once per image, running all the tests as individual test methods against that image/server, and then cleaning it up after the tests are done).

I tested this against KVM and bare metal on uc_dev. If this approach looks good I can update the base configs for the different sites too.