### PR TITLE
Skip lease tests that require a physical host reservation if they're …

### DIFF
--- a/src/blazar_tempest_plugin/tests/api/leases/test_leases.py
+++ b/src/blazar_tempest_plugin/tests/api/leases/test_leases.py
@@ -131,6 +131,12 @@ class TestLeasesHosts(ReservationApiTest):
     Basic tests that leasing a host behaves as expected.
     """
 
+    @classmethod
+    def skip_checks(cls):
+        super(TestLeasesHosts, cls).skip_checks()
+        if not CONF.reservation_feature_enabled.host_plugin:
+            raise cls.skipException("host reservations are not enabled")
+
     def test_get_reserved_host_single(self):
         """Test that if lease has reservation for hosts, included hosts can be queried."""
 


### PR DESCRIPTION
…not enabled