### PR TITLE
Add lease tests for edge

### DIFF
--- a/src/blazar_tempest_plugin/tests/api/leases/test_lease_devices.py
+++ b/src/blazar_tempest_plugin/tests/api/leases/test_lease_devices.py
@@ -61,7 +61,14 @@ class TestLeaseContainers(ContainerApiBase):
                 self.container.uuid, "Deleted"
             )
         except exceptions.NotFound:
-            pass
+            container_deleted = True
+        else:
+            container_deleted = False
+            _, container = self.container_client.get_container(self.container.uuid)
+            self.assertEqual("Deleted", container.status)
+
+        self.assertTrue(container_deleted or container.status == "Deleted",
+                        "Container was not deleted after lease deletion")
 
     @decorators.attr(type="smoke")
     def test_device_not_in_multiple_leases(self):


### PR DESCRIPTION
```
$ tempest run --exclude-list etc/exclude_list --concurrency 1 --regex "blazar_tempest_plugin.tests.api.leases.test_lease_devices"                              
{0} blazar_tempest_plugin.tests.api.leases.test_lease_devices.TestLeaseContainers.test_delete_lease_with_container [60.605183s] ... ok
{0} blazar_tempest_plugin.tests.api.leases.test_lease_devices.TestLeaseContainers.test_device_in_lease [46.446012s] ... ok
{0} blazar_tempest_plugin.tests.api.leases.test_lease_devices.TestLeaseContainers.test_device_not_in_multiple_leases [53.092664s] ... ok
{0} blazar_tempest_plugin.tests.api.leases.test_lease_devices.TestLeaseContainers.test_extend_lease_for_reserved_container [47.583610s] ... ok

======
Totals
======
Ran: 4 tests in 207.7352 sec.
 - Passed: 4
 - Skipped: 0
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 207.7275 sec.
```