### PR TITLE
Flag individual image tests with their alert level

### DIFF
--- a/src/blazar_tempest_plugin/tests/scenario/test_images.py
+++ b/src/blazar_tempest_plugin/tests/scenario/test_images.py
@@ -1,5 +1,7 @@
 import sys
 
+from enum import Enum
+
 from oslo_log import log as logging
 from tempest import config
 from tempest.common import waiters as tempest_waiters
@@ -16,6 +18,11 @@ from blazar_tempest_plugin.tests.scenario.base import ReservationScenarioTest
 
 CONF = config.CONF
 LOG = logging.getLogger(__name__)
+
+
+class AlertLevel(Enum):
+    CRITICAL = 1
+    NONCRITICAL = 2
 
 
 ### Tests ###
@@ -72,11 +79,11 @@ def verify_rclone_and_object_store(self, remote):
 
 
 TESTS = [
-    ("verify_cloud_init", verify_cloud_init),
-    ("verify_openrc_exists", verify_openrc_exists),
-    ("verify_ssh_key_injection", verify_ssh_key_injection),
-    ("verify_rclone_and_object_store", verify_rclone_and_object_store),
-    ("verify_openrc", verify_openrc),
+    (AlertLevel.NONCRITICAL, "verify_cloud_init", verify_cloud_init),
+    (AlertLevel.NONCRITICAL, "verify_openrc_exists", verify_openrc_exists),
+    (AlertLevel.CRITICAL, "verify_ssh_key_injection", verify_ssh_key_injection),
+    (AlertLevel.CRITICAL, "verify_rclone_and_object_store", verify_rclone_and_object_store),
+    (AlertLevel.NONCRITICAL, "verify_openrc", verify_openrc),
 ]
 
 
@@ -223,8 +230,8 @@ def make_image_test_class(image_name):
             finally:
                 super(TestImage, cls).resource_cleanup()
 
-    for test_name, test_func in TESTS:
-        def make_test(test_name, test_func):
+    for alert_level, test_name, test_func in TESTS:
+        def make_test(alert_level, test_name, test_func):
             def test_fn(self):
                 if should_skip(test_name, CONF.image.cc_image_tests_skip_test_regex):
                     self.skipTest(f"{test_name} skipped")
@@ -232,12 +239,12 @@ def make_image_test_class(image_name):
                     test_func(self, type(self).remote, type(self).public_key)
                 else:
                     test_func(self, type(self).remote)
-            test_fn.__name__ = f"test_{test_name}"
+            test_fn.__name__ = f"test_{alert_level}_{test_name}"
             test_fn.__qualname__ = f"{class_name}.{test_fn.__name__}"
             test_fn.__module__ = __name__
             return decorators.attr(type="smoke")(test_fn)
 
-        test_method = make_test(test_name, test_func)
+        test_method = make_test(alert_level.name, test_name, test_func)
         setattr(TestImage, test_method.__name__, test_method)
 
     TestImage.__name__ = class_name


### PR DESCRIPTION
Since we are keying off of the regex for running different groups (PRs coming soon for that stuff on other repos), I added this to the individual image tests so we can run CRITICAL vs NONCRITICAL for routing purposes. For example:

Run all critical image tests:
```
$ tempest run --exclude-list etc/exclude_list --concurrency 1 --regex "blazar_tempest_plugin.tests.scenario.test_images.(?\!.*NONCRITICAL).*" 
{0} blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_Ubuntu22_04.test_CRITICAL_verify_rclone_and_object_store ... SKIPPED: verify_rclone_and_object_store skipped
{0} blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_Ubuntu22_04.test_CRITICAL_verify_ssh_key_injection [0.595781s] ... ok
{0} blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_Ubuntu24_04.test_CRITICAL_verify_rclone_and_object_store ... SKIPPED: verify_rclone_and_object_store skipped
{0} blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_Ubuntu24_04.test_CRITICAL_verify_ssh_key_injection [0.640982s] ... ok
```

Or run all NONCRITICAL tests:
```
$ tempest run --exclude-list etc/exclude_list --concurrency 1 --regex ".*NONCRITICAL.*"                                 
{0} blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_Ubuntu22_04.test_NONCRITICAL_verify_cloud_init [6.864865s] ... ok
{0} blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_Ubuntu22_04.test_NONCRITICAL_verify_openrc ... SKIPPED: verify_openrc skipped
{0} blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_Ubuntu22_04.test_NONCRITICAL_verify_openrc_exists ... SKIPPED: verify_openrc_exists skipped
{0} blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_Ubuntu24_04.test_NONCRITICAL_verify_cloud_init [2.182266s] ... ok
{0} blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_Ubuntu24_04.test_NONCRITICAL_verify_openrc ... SKIPPED: verify_openrc skipped
{0} blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_Ubuntu24_04.test_NONCRITICAL_verify_openrc_exists ... SKIPPED: verify_openrc_exists skipped
```