### PR TITLE
add slow and criticality labels to image tests

### DIFF
--- a/src/blazar_tempest_plugin/tests/scenario/test_images.py
+++ b/src/blazar_tempest_plugin/tests/scenario/test_images.py
@@ -239,14 +239,17 @@ def make_image_test_class(image_name):
                     test_func(self, type(self).remote, type(self).public_key)
                 else:
                     test_func(self, type(self).remote)
-            test_fn.__name__ = f"test_{alert_level}_{test_name}"
+            test_fn.__name__ = f"test_{test_name}"
             test_fn.__qualname__ = f"{class_name}.{test_fn.__name__}"
             test_fn.__module__ = __name__
-            test_type = "smoke"
-            if alert_level == "NONCRITICAL":
-                test_type = "non_critical"
-            test_fn = decorators.attr(type=test_type)(test_fn)
-            return test_fn
+
+            # annotate test with multiple types for filtering
+            test_attr_type = [
+                "slow",
+                alert_level.lower(),
+            ]
+            decorated_test_fn = decorators.attr(type=test_attr_type)(test_fn)
+            return decorated_test_fn
 
         test_method = make_test(alert_level.name, test_name, test_func)
         setattr(TestImage, test_method.__name__, test_method)


### PR DESCRIPTION
Need to check if this works, but decorators.attr is supposed to take a string or list of strings as argument

Using this method, we get the following output:
```
tempest run --list-tests --regex 'blazar_tempest_plugin.tests.scenario.test_images.*noncritical'

blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_Ubuntu24_04.test_verify_cloud_init[noncritical,slow]
blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_Ubuntu24_04_CUDA.test_verify_cloud_init[noncritical,slow]
blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_Ubuntu22_04.test_verify_cloud_init[noncritical,slow]
blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_Ubuntu24_04.test_verify_openrc_exists[noncritical,slow]
blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_CentOS9_Stream.test_verify_openrc_exists[noncritical,slow]
blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_CentOS9_Stream.test_verify_openrc[noncritical,slow]
blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_Ubuntu24_04_CUDA.test_verify_openrc[noncritical,slow]
blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_Ubuntu22_04.test_verify_openrc_exists[noncritical,slow]
blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_Ubuntu22_04_CUDA.test_verify_cloud_init[noncritical,slow]
blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_Ubuntu24_04_CUDA.test_verify_openrc_exists[noncritical,slow]
blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_CentOS9_Stream.test_verify_cloud_init[noncritical,slow]
blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_Ubuntu22_04.test_verify_openrc[noncritical,slow]
blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_Ubuntu22_04_CUDA.test_verify_openrc[noncritical,slow]
blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_Ubuntu22_04_CUDA.test_verify_openrc_exists[noncritical,slow]
blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_Ubuntu24_04.test_verify_openrc[noncritical,slow]
```

and:
```
tempest run --list-tests --regex 'blazar_tempest_plugin\.tests\.scenario\.test_images.*(?<!non)critical'

blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_Ubuntu22_04.test_verify_ssh_key_injection[critical,slow]
blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_Ubuntu24_04_CUDA.test_verify_rclone_and_object_store[critical,slow]
blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_CentOS9_Stream.test_verify_ssh_key_injection[critical,slow]
blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_Ubuntu22_04_CUDA.test_verify_ssh_key_injection[critical,slow]
blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_CentOS9_Stream.test_verify_rclone_and_object_store[critical,slow]
blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_Ubuntu22_04.test_verify_rclone_and_object_store[critical,slow]
blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_Ubuntu22_04_CUDA.test_verify_rclone_and_object_store[critical,slow]
blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_Ubuntu24_04.test_verify_rclone_and_object_store[critical,slow]
blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_Ubuntu24_04.test_verify_ssh_key_injection[critical,slow]
blazar_tempest_plugin.tests.scenario.test_images.TestImage_CC_Ubuntu24_04_CUDA.test_verify_ssh_key_injection[critical,slow]
```