### PR TITLE
set longer timeout for ssh

### DIFF
--- a/src/blazar_tempest_plugin/tests/scenario/test_device_basic_ops.py
+++ b/src/blazar_tempest_plugin/tests/scenario/test_device_basic_ops.py
@@ -138,7 +138,7 @@ class ReservationZunTest(ReservationScenarioTest):
         )
 
         # verify we can ping the floating IP
-        utils.ping_ip(fip_addr)
+        utils.ping_ip(fip_addr, timeout=120)
 
         # verify we can delete the container's floating IP and it goes away
         self.floating_ips_client.delete_floatingip(fip["floatingip"]["id"])


### PR DESCRIPTION
sometimes attaching a floating IP seems to take a while, increase timeout to see if this is a persistent failure, or just slowness